### PR TITLE
INDY-878: move validator info files back from ledger dir to genesis d…

### DIFF
--- a/plenum/cli/cli.py
+++ b/plenum/cli/cli.py
@@ -943,10 +943,7 @@ class Cli:
                                     self.nodes.values())
                 node = self.NodeClass(name,
                                       nodeRegistry=nodeRegistry,
-                                      ledger_dir=config_helper.ledger_dir,
-                                      keys_dir=config_helper.keys_dir,
-                                      genesis_dir=config_helper.genesis_dir,
-                                      plugins_dir=config_helper.plugins_dir,
+                                      config_helper=config_helper,
                                       pluginPaths=self.pluginPaths,
                                       config=self.config)
             except KeysNotFoundException as e:

--- a/plenum/common/config_helper.py
+++ b/plenum/common/config_helper.py
@@ -33,6 +33,10 @@ class PConfigHelper():
     def keys_dir(self):
         return self.chroot_if_needed(self.config.KEYS_DIR)
 
+    @property
+    def node_info_dir(self):
+        return self.chroot_if_needed(self.config.NODE_INFO_DIR)
+
 
 class PNodeConfigHelper(PConfigHelper):
 

--- a/plenum/server/general_config/ubuntu_platform_config.py
+++ b/plenum/server/general_config/ubuntu_platform_config.py
@@ -15,3 +15,6 @@ BACKUP_DIR = '/var/lib/indy/backup'
 
 # Directory to store plugins.
 PLUGINS_DIR = '/var/lib/indy/plugins'
+
+# Directory to store node info.
+NODE_INFO_DIR = '/var/lib/indy'

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -131,6 +131,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
                  keys_dir: str = None,
                  genesis_dir: str = None,
                  plugins_dir: str = None,
+                 node_info_dir: str = None,
                  view_changer: ViewChanger = None,
                  primaryDecider: PrimaryDecider = None,
                  pluginPaths: Iterable[str] = None,
@@ -155,6 +156,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         self.keys_dir = keys_dir or self.config_helper.keys_dir
         self.genesis_dir = genesis_dir or self.config_helper.genesis_dir
         self.plugins_dir = plugins_dir or self.config_helper.plugins_dir
+        self.node_info_dir = node_info_dir or self.config_helper.node_info_dir
 
         self._view_change_timeout = self.config.VIEW_CHANGE_TIMEOUT
 
@@ -2751,6 +2753,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
             'keys_dir': self.keys_dir,
             'genesis_dir': self.genesis_dir,
             'plugins_dir': self.plugins_dir,
+            'node_info_dir': self.node_info_dir,
             'portN': self.nodestack.ha[1],
             'portC': self.clientstack.ha[1],
             'address': nodeAddress

--- a/plenum/server/validator_info_tool.py
+++ b/plenum/server/validator_info_tool.py
@@ -30,7 +30,7 @@ class ValidatorNodeInfoTool:
     def __init__(self, node):
         self._node = node
         self.__name = self._node.name
-        self.__ledger_dir = self._node.ledger_dir
+        self.__node_info_dir = self._node.node_info_dir
 
     @property
     def info(self):
@@ -167,6 +167,6 @@ class ValidatorNodeInfoTool:
 
     def dump_json_file(self):
         file_name = self.FILE_NAME_TEMPLATE.format(node_name=self.__name.lower())
-        path = os.path.join(self.__ledger_dir, file_name)
+        path = os.path.join(self.__node_info_dir, file_name)
         with open(path, 'w') as fd:
             json.dump(self.info, fd)

--- a/plenum/test/conftest.py
+++ b/plenum/test/conftest.py
@@ -922,10 +922,7 @@ def testNode(pluginManager, tdir, tconf, node_config_helper_class):
     config_helper = node_config_helper_class(name, tconf, chroot=tdir)
     node = TestNode(name=name, ha=ha, cliname=cliname, cliha=cliha,
                     nodeRegistry=copy(nodeReg),
-                    ledger_dir=config_helper.ledger_dir,
-                    keys_dir=config_helper.keys_dir,
-                    genesis_dir=config_helper.genesis_dir,
-                    plugins_dir=config_helper.plugins_dir,
+                    config_helper=config_helper,
                     config=tconf,
                     primaryDecider=None, pluginPaths=None, seed=randomSeed())
     node.start(None)

--- a/plenum/test/node_catchup/test_node_catchup_after_restart_after_txns.py
+++ b/plenum/test/node_catchup/test_node_catchup_after_restart_after_txns.py
@@ -65,10 +65,7 @@ def test_node_catchup_after_restart_with_txns(
     config_helper = PNodeConfigHelper(newNode.name, tconf, chroot=tdir)
     newNode = TestNode(
         newNode.name,
-        ledger_dir=config_helper.ledger_dir,
-        keys_dir=config_helper.keys_dir,
-        genesis_dir=config_helper.genesis_dir,
-        plugins_dir=config_helper.plugins_dir,
+        config_helper=config_helper,
         config=tconf,
         ha=nodeHa,
         cliha=nodeCHa,

--- a/plenum/test/node_catchup/test_node_catchup_after_restart_no_txns.py
+++ b/plenum/test/node_catchup/test_node_catchup_after_restart_no_txns.py
@@ -51,10 +51,7 @@ def test_node_catchup_after_restart_no_txns(
     config_helper = PNodeConfigHelper(new_node.name, tconf, chroot=tdir)
     new_node = TestNode(
         new_node.name,
-        ledger_dir=config_helper.ledger_dir,
-        keys_dir=config_helper.keys_dir,
-        genesis_dir=config_helper.genesis_dir,
-        plugins_dir=config_helper.plugins_dir,
+        config_helper=config_helper,
         config=tconf,
         ha=nodeHa,
         cliha=nodeCHa,

--- a/plenum/test/plugin/stats_consumer/plugin_stats_consumer.py
+++ b/plenum/test/plugin/stats_consumer/plugin_stats_consumer.py
@@ -61,6 +61,7 @@ class TestStatsConsumer(StatsConsumer):
         assert 'keys_dir' in nodeInfo
         assert 'genesis_dir' in nodeInfo
         assert 'plugins_dir' in nodeInfo
+        assert 'node_info_dir' in nodeInfo
         assert 'portN' in nodeInfo
         assert 'portC' in nodeInfo
         assert 'address' in nodeInfo

--- a/plenum/test/pool_transactions/helper.py
+++ b/plenum/test/pool_transactions/helper.py
@@ -121,10 +121,7 @@ def start_newly_added_node(
         nodeClass):
     config_helper = PNodeConfigHelper(node_name, tconf, chroot=tdir)
     node = nodeClass(node_name,
-                     ledger_dir=config_helper.ledger_dir,
-                     keys_dir=config_helper.keys_dir,
-                     genesis_dir=config_helper.genesis_dir,
-                     plugins_dir=config_helper.plugins_dir,
+                     config_helper=config_helper,
                      config=tconf,
                      ha=node_ha, cliha=client_ha,
                      pluginPaths=plugin_path)
@@ -225,10 +222,7 @@ def updateNodeDataAndReconnect(looper, steward, stewardWallet, node,
     looper.removeProdable(name=node.name)
     config_helper = PNodeConfigHelper(node_alias, tconf, chroot=tdir)
     restartedNode = TestNode(node_alias,
-                             ledger_dir=config_helper.ledger_dir,
-                             keys_dir=config_helper.keys_dir,
-                             genesis_dir=config_helper.genesis_dir,
-                             plugins_dir=config_helper.plugins_dir,
+                             config_helper=config_helper,
                              config=tconf,
                              ha=HA(node_ip, node_port),
                              cliha=HA(client_ip, client_port))

--- a/plenum/test/pool_transactions/test_change_ha_persists_post_nodes_restart.py
+++ b/plenum/test/pool_transactions/test_change_ha_persists_post_nodes_restart.py
@@ -47,10 +47,7 @@ def testChangeHaPersistsPostNodesRestart(looper, txnPoolNodeSet, tdir, tdirWithP
     for node in txnPoolNodeSet[:-1]:
         config_helper = PNodeConfigHelper(node.name, tconf, chroot=tdir)
         restartedNode = TestNode(node.name,
-                                 ledger_dir=config_helper.ledger_dir,
-                                 keys_dir=config_helper.keys_dir,
-                                 genesis_dir=config_helper.genesis_dir,
-                                 plugins_dir=config_helper.plugins_dir,
+                                 config_helper=config_helper,
                                  config=tconf, ha=node.nodestack.ha,
                                  cliha=node.clientstack.ha)
         looper.add(restartedNode)
@@ -59,10 +56,7 @@ def testChangeHaPersistsPostNodesRestart(looper, txnPoolNodeSet, tdir, tdirWithP
     # Starting the node whose HA was changed
     config_helper = PNodeConfigHelper(newNode.name, tconf, chroot=tdir)
     node = TestNode(newNode.name,
-                    ledger_dir=config_helper.ledger_dir,
-                    keys_dir=config_helper.keys_dir,
-                    genesis_dir=config_helper.genesis_dir,
-                    plugins_dir=config_helper.plugins_dir,
+                    config_helper=config_helper,
                     config=tconf,
                     ha=nodeNewHa, cliha=clientNewHa)
     looper.add(node)

--- a/plenum/test/pool_transactions/test_client_with_pool_txns.py
+++ b/plenum/test/pool_transactions/test_client_with_pool_txns.py
@@ -74,10 +74,7 @@ def testClientConnectToRestartedNodes(looper, txnPoolNodeSet, tdirWithPoolTxns,
     for nm in poolTxnNodeNames:
         config_helper = PNodeConfigHelper(nm, tconf, chroot=tdir)
         node = TestNode(nm,
-                        ledger_dir=config_helper.ledger_dir,
-                        keys_dir=config_helper.keys_dir,
-                        genesis_dir=config_helper.genesis_dir,
-                        plugins_dir=config_helper.plugins_dir,
+                        config_helper=config_helper,
                         config=tconf, pluginPaths=allPluginsPath)
         looper.add(node)
         txnPoolNodeSet.append(node)

--- a/plenum/test/pool_transactions/test_nodes_ha_change_back.py
+++ b/plenum/test/pool_transactions/test_nodes_ha_change_back.py
@@ -47,10 +47,7 @@ def testChangeNodeHaBack(looper, txnPoolNodeSet, tdir, tconf,
     # during the steps, only the final result is checked.
     config_helper = PNodeConfigHelper(theta.name, tconf, chroot=tdir)
     restartedNode = TestNode(theta.name,
-                             ledger_dir=config_helper.ledger_dir,
-                             keys_dir=config_helper.keys_dir,
-                             genesis_dir=config_helper.genesis_dir,
-                             plugins_dir=config_helper.plugins_dir,
+                             config_helper=config_helper,
                              config=tconf, ha=correctNodeHa, cliha=clientHa)
     looper.add(restartedNode)
     txnPoolNodeSet[-1] = restartedNode

--- a/plenum/test/pool_transactions/test_z_node_key_changed.py
+++ b/plenum/test/pool_transactions/test_z_node_key_changed.py
@@ -46,10 +46,7 @@ def testNodeKeysChanged(looper, txnPoolNodeSet, tdir,
     logger.debug("{} starting with HAs {} {}".format(newNode, nodeHa, nodeCHa))
 
     node = TestNode(newNode.name,
-                    ledger_dir=config_helper.ledger_dir,
-                    keys_dir=config_helper.keys_dir,
-                    genesis_dir=config_helper.genesis_dir,
-                    plugins_dir=config_helper.plugins_dir,
+                    config_helper=config_helper,
                     config=tconf,
                     ha=nodeHa, cliha=nodeCHa, pluginPaths=allPluginsPath)
     looper.add(node)

--- a/plenum/test/primary_selection/test_primary_selection_after_primary_demotion_and_pool_restart.py
+++ b/plenum/test/primary_selection/test_primary_selection_after_primary_demotion_and_pool_restart.py
@@ -50,10 +50,7 @@ def test_primary_selection_after_primary_demotion_and_pool_restart(looper,
     for node in txnPoolNodeSet:
         config_helper = PNodeConfigHelper(node.name, tconf, chroot=tdir)
         restartedNode = TestNode(node.name,
-                                 ledger_dir=config_helper.ledger_dir,
-                                 keys_dir=config_helper.keys_dir,
-                                 genesis_dir=config_helper.genesis_dir,
-                                 plugins_dir=config_helper.plugins_dir,
+                                 config_helper=config_helper,
                                  config=tconf, ha=node.nodestack.ha,
                                  cliha=node.clientstack.ha)
         looper.add(restartedNode)

--- a/plenum/test/script/helper.py
+++ b/plenum/test/script/helper.py
@@ -60,10 +60,7 @@ def changeNodeHa(looper, txnPoolNodeSet, tdirWithClientPoolTxns,
     # start node with new HA
     config_helper = PNodeConfigHelper(subjectedNode.name, tconf, chroot=tdir)
     restartedNode = TestNode(subjectedNode.name,
-                             ledger_dir=config_helper.ledger_dir,
-                             keys_dir=config_helper.keys_dir,
-                             genesis_dir=config_helper.genesis_dir,
-                             plugins_dir=config_helper.plugins_dir,
+                             config_helper=config_helper,
                              config=tconf, ha=nodeStackNewHA,
                              cliha=clientStackNewHA)
     looper.add(restartedNode)

--- a/plenum/test/test_node.py
+++ b/plenum/test/test_node.py
@@ -527,10 +527,7 @@ class TestNodeSet(ExitStack):
                           cliname=cliname,
                           cliha=cliha,
                           nodeRegistry=copy(self.nodeReg),
-                          ledger_dir=config_helper.ledger_dir,
-                          keys_dir=config_helper.keys_dir,
-                          genesis_dir=config_helper.genesis_dir,
-                          plugins_dir=config_helper.plugins_dir,
+                          config_helper=config_helper,
                           primaryDecider=self.primaryDecider,
                           pluginPaths=self.pluginPaths,
                           seed=seed))

--- a/plenum/test/test_node_connection.py
+++ b/plenum/test/test_node_connection.py
@@ -53,10 +53,7 @@ def testNodesConnectsWhenOneNodeIsLate(allPluginsPath, tdir_for_func, tconf_for_
     def create(name):
         config_helper = PNodeConfigHelper(name, tconf_for_func, chroot=tdir_for_func)
         node = TestNode(name, nodeReg,
-                        ledger_dir=config_helper.ledger_dir,
-                        keys_dir=config_helper.keys_dir,
-                        genesis_dir=config_helper.genesis_dir,
-                        plugins_dir=config_helper.plugins_dir,
+                        config_helper=config_helper,
                         config=tconf_for_func,
                         pluginPaths=allPluginsPath)
         nodes.append(node)
@@ -98,10 +95,7 @@ def testNodesConnectWhenTheyAllStartAtOnce(allPluginsPath, tdir_for_func, tconf_
     for name in nodeReg:
         config_helper = PNodeConfigHelper(name, tconf_for_func, chroot=tdir_for_func)
         node = TestNode(name, nodeReg,
-                        ledger_dir=config_helper.ledger_dir,
-                        keys_dir=config_helper.keys_dir,
-                        genesis_dir=config_helper.genesis_dir,
-                        plugins_dir=config_helper.plugins_dir,
+                        config_helper=config_helper,
                         config=tconf_for_func,
                         pluginPaths=allPluginsPath)
         nodes.append(node)
@@ -138,10 +132,7 @@ def testNodesComingUpAtDifferentTimes(allPluginsPath, tdir_for_func, tconf_for_f
     for name in names:
         config_helper = PNodeConfigHelper(name, tconf_for_func, chroot=tdir_for_func)
         node = TestNode(name, nodeReg,
-                        ledger_dir=config_helper.ledger_dir,
-                        keys_dir=config_helper.keys_dir,
-                        genesis_dir=config_helper.genesis_dir,
-                        plugins_dir=config_helper.plugins_dir,
+                        config_helper=config_helper,
                         config=tconf_for_func,
                         pluginPaths=allPluginsPath)
         nodes.append(node)
@@ -188,10 +179,7 @@ def testNodeConnection(allPluginsPath, tdir_for_func, tconf_for_func,
     for name in names:
         config_helper = PNodeConfigHelper(name, tconf_for_func, chroot=tdir_for_func)
         node = TestNode(name, nrg,
-                        ledger_dir=config_helper.ledger_dir,
-                        keys_dir=config_helper.keys_dir,
-                        genesis_dir=config_helper.genesis_dir,
-                        plugins_dir=config_helper.plugins_dir,
+                        config_helper=config_helper,
                         config=tconf_for_func,
                         pluginPaths=allPluginsPath)
         nodes.append(node)
@@ -232,10 +220,7 @@ def testNodeRemoveUnknownRemote(allPluginsPath, tdir_for_func, tconf_for_func,
     for name in names:
         config_helper = PNodeConfigHelper(name, tconf_for_func, chroot=tdir_for_func)
         node = TestNode(name, nrg,
-                        ledger_dir=config_helper.ledger_dir,
-                        keys_dir=config_helper.keys_dir,
-                        genesis_dir=config_helper.genesis_dir,
-                        plugins_dir=config_helper.plugins_dir,
+                        config_helper=config_helper,
                         config=tconf_for_func,
                         pluginPaths=allPluginsPath)
         nodes.append(node)
@@ -252,10 +237,7 @@ def testNodeRemoveUnknownRemote(allPluginsPath, tdir_for_func, tconf_for_func,
     initLocalKeys(tdir_for_func, tconf_for_func, {name: nodeReg[name]})
     config_helper = PNodeConfigHelper(name, tconf_for_func, chroot=tdir_for_func)
     C = TestNode(name, {**nrg, **{name: nodeReg[name]}},
-                 ledger_dir=config_helper.ledger_dir,
-                 keys_dir=config_helper.keys_dir,
-                 genesis_dir=config_helper.genesis_dir,
-                 plugins_dir=config_helper.plugins_dir,
+                 config_helper=config_helper,
                  config=tconf_for_func,
                  pluginPaths=allPluginsPath)
     for node in nodes:

--- a/plenum/test/test_state_regenerated_from_ledger.py
+++ b/plenum/test/test_state_regenerated_from_ledger.py
@@ -46,10 +46,7 @@ def test_state_regenerated_from_ledger(
 
     config_helper = PNodeConfigHelper(node_to_stop.name, tconf, chroot=tdir)
     restarted_node = TestNode(node_to_stop.name,
-                              ledger_dir=config_helper.ledger_dir,
-                              keys_dir=config_helper.keys_dir,
-                              genesis_dir=config_helper.genesis_dir,
-                              plugins_dir=config_helper.plugins_dir,
+                              config_helper=config_helper,
                               config=tconf, ha=nodeHa, cliha=nodeCHa,
                               pluginPaths=allPluginsPath)
     looper.add(restarted_node)

--- a/plenum/test/validator_info/test_validator_info.py
+++ b/plenum/test/validator_info/test_validator_info.py
@@ -195,7 +195,7 @@ def load_info(path):
 
 @pytest.fixture(scope='module')
 def info_path(patched_dump_info_period, txnPoolNodesLooper, txnPoolNodeSet, node):
-    path = os.path.join(node.ledger_dir, INFO_FILENAME)
+    path = os.path.join(node.node_info_dir, INFO_FILENAME)
     txnPoolNodesLooper.runFor(patched_dump_info_period)
     assert os.path.exists(path), '{} exists'.format(path)
     return path

--- a/plenum/test/view_change/helper.py
+++ b/plenum/test/view_change/helper.py
@@ -27,10 +27,7 @@ def start_stopped_node(stopped_node, looper, tconf,
                                                         stopped_node.clientstack.ha)
     config_helper = PNodeConfigHelper(stopped_node.name, tconf, chroot=tdir)
     restarted_node = TestNode(stopped_node.name,
-                              ledger_dir=config_helper.ledger_dir,
-                              keys_dir=config_helper.keys_dir,
-                              genesis_dir=config_helper.genesis_dir,
-                              plugins_dir=config_helper.plugins_dir,
+                              config_helper=config_helper,
                               config=tconf,
                               ha=nodeHa, cliha=nodeCHa,
                               pluginPaths=allPluginsPath)

--- a/plenum/test/zstack_tests/test_zstack_reconnection.py
+++ b/plenum/test/zstack_tests/test_zstack_reconnection.py
@@ -51,10 +51,7 @@ def testZStackNodeReconnection(tconf, looper, txnPoolNodeSet, client1, wallet1,
     config_helper = PNodeConfigHelper(nodeToCrash.name, tconf, chroot=tdir)
     node = TestNode(
         nodeToCrash.name,
-        ledger_dir=config_helper.ledger_dir,
-        keys_dir=config_helper.keys_dir,
-        genesis_dir=config_helper.genesis_dir,
-        plugins_dir=config_helper.plugins_dir,
+        config_helper=config_helper,
         config=tconf,
         ha=nodeToCrash.nodestack.ha,
         cliha=nodeToCrash.clientstack.ha)


### PR DESCRIPTION
…ir. (#479)

* INDY-878: move validator info files back from ledger dir to genesis dir.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Add NODE_INFO_DIR parameter into config.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Fix test node initialisation.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Get back passing of node info dir using node class object.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Pass config_helper instead of separate paths to Node class.

It is done to reduce changes in code that should be done in case
of adding/removing of ConfigHelper properties.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Add node_info_dir to node stats data.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Fix test_node_connection tests.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>